### PR TITLE
Auto-dedupe the all-time leaderboard (--dedupe-all)

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -3,24 +3,31 @@ set -eu
 
 DB_PATH="${CLOCK_DB_PATH:-/data/clock.db}"
 
-# One-time, opt-in user merge: fold one Discord account's ClockBot stats into
-# another. It is keyed by user_id (the stable Discord account id), because the
-# username column holds the mutable display name. Configure with CLOCK_MERGE_*:
+# One-time, opt-in user merge. Keyed by user_id (the stable Discord account id),
+# because the username column holds the mutable display name. Pick one:
 #
-#   CLOCK_MERGE_INTO_ID / CLOCK_MERGE_FROM_ID      (recommended, unambiguous)
-#   CLOCK_MERGE_INTO_NAME / CLOCK_MERGE_FROM_NAME  (resolved to a single id, else it skips)
-#   CLOCK_MERGE_NAME                               (optional canonical display name)
+#   CLOCK_MERGE_DEDUPE_ALL=1                        auto-fix the leaderboard: fold
+#                                                   every display name shared by
+#                                                   more than one account into the
+#                                                   account with the most hours
+#                                                   (the smaller id is overridden)
+#   CLOCK_MERGE_DEDUPE_NAME=<name>                  same, for one display name only
+#   CLOCK_MERGE_INTO_ID / CLOCK_MERGE_FROM_ID       merge two specific accounts
+#   CLOCK_MERGE_INTO_NAME / CLOCK_MERGE_FROM_NAME   same, by name (must be unique)
+#   CLOCK_MERGE_NAME                                optional canonical display name
 #
 # Guarded so the migration can never stop the bot from starting.
-if [ -n "${CLOCK_MERGE_INTO_ID:-}${CLOCK_MERGE_INTO_NAME:-}" ] \
-  && [ -n "${CLOCK_MERGE_FROM_ID:-}${CLOCK_MERGE_FROM_NAME:-}" ]; then
+if [ -n "${CLOCK_MERGE_DEDUPE_ALL:-}${CLOCK_MERGE_DEDUPE_NAME:-}" ] \
+  || { [ -n "${CLOCK_MERGE_INTO_ID:-}${CLOCK_MERGE_INTO_NAME:-}" ] && [ -n "${CLOCK_MERGE_FROM_ID:-}${CLOCK_MERGE_FROM_NAME:-}" ]; }; then
   if [ -f "$DB_PATH" ]; then
     MERGE_ARGS=""
-    [ -n "${CLOCK_MERGE_INTO_ID:-}" ]   && MERGE_ARGS="$MERGE_ARGS --into-id ${CLOCK_MERGE_INTO_ID}"
-    [ -n "${CLOCK_MERGE_INTO_NAME:-}" ] && MERGE_ARGS="$MERGE_ARGS --into-name ${CLOCK_MERGE_INTO_NAME}"
-    [ -n "${CLOCK_MERGE_FROM_ID:-}" ]   && MERGE_ARGS="$MERGE_ARGS --from-id ${CLOCK_MERGE_FROM_ID}"
-    [ -n "${CLOCK_MERGE_FROM_NAME:-}" ] && MERGE_ARGS="$MERGE_ARGS --from-name ${CLOCK_MERGE_FROM_NAME}"
-    [ -n "${CLOCK_MERGE_NAME:-}" ]      && MERGE_ARGS="$MERGE_ARGS --name ${CLOCK_MERGE_NAME}"
+    [ -n "${CLOCK_MERGE_DEDUPE_ALL:-}" ]  && MERGE_ARGS="$MERGE_ARGS --dedupe-all"
+    [ -n "${CLOCK_MERGE_DEDUPE_NAME:-}" ] && MERGE_ARGS="$MERGE_ARGS --dedupe-name ${CLOCK_MERGE_DEDUPE_NAME}"
+    [ -n "${CLOCK_MERGE_INTO_ID:-}" ]     && MERGE_ARGS="$MERGE_ARGS --into-id ${CLOCK_MERGE_INTO_ID}"
+    [ -n "${CLOCK_MERGE_INTO_NAME:-}" ]   && MERGE_ARGS="$MERGE_ARGS --into-name ${CLOCK_MERGE_INTO_NAME}"
+    [ -n "${CLOCK_MERGE_FROM_ID:-}" ]     && MERGE_ARGS="$MERGE_ARGS --from-id ${CLOCK_MERGE_FROM_ID}"
+    [ -n "${CLOCK_MERGE_FROM_NAME:-}" ]   && MERGE_ARGS="$MERGE_ARGS --from-name ${CLOCK_MERGE_FROM_NAME}"
+    [ -n "${CLOCK_MERGE_NAME:-}" ]        && MERGE_ARGS="$MERGE_ARGS --name ${CLOCK_MERGE_NAME}"
 
     echo "[clock] running one-time user merge on $DB_PATH"
     # shellcheck disable=SC2086

--- a/scripts/merge_clock_user.py
+++ b/scripts/merge_clock_user.py
@@ -26,14 +26,25 @@ Safety
 It touches: sessions, weekly_archive, activity_archive.
 
 Usage:
-    # by Discord user_id (recommended, unambiguous)
+    # auto-fix the whole leaderboard: fold every duplicate-display-name account
+    # into its largest one (overrides the smaller account's user_id)
+    merge_clock_user.py /data/clock.db --dedupe-all
+
+    # see every account and any display name shared by more than one account
+    merge_clock_user.py /data/clock.db --list
+
+    # two leaderboard rows show the SAME name: merge them in one shot
+    # (folds every account with this name into the one with the most hours)
+    merge_clock_user.py /data/clock.db --dedupe-name Thirsty
+
+    # merge two specific accounts by Discord user_id (unambiguous)
     merge_clock_user.py /data/clock.db --into-id 111 --from-id 222 --name x
 
-    # by display name (resolved to a single user_id each, else it safely skips)
+    # by display name (each must resolve to a single user_id, else it skips)
     merge_clock_user.py /data/clock.db --into-name x --from-name x_
 
     # preview only
-    merge_clock_user.py /data/clock.db --into-id 111 --from-id 222 --dry-run
+    merge_clock_user.py /data/clock.db --dedupe-name Thirsty --dry-run
 """
 
 from __future__ import annotations
@@ -143,6 +154,144 @@ def merge_dupes(conn: sqlite3.Connection, table: str, key_cols: tuple[str, ...])
     return deleted
 
 
+def total_minutes(conn: sqlite3.Connection, uid: str) -> int:
+    s = conn.execute(
+        "SELECT COALESCE(SUM(minutes),0) FROM sessions WHERE user_id=? AND ended_at IS NOT NULL",
+        (uid,),
+    ).fetchone()[0]
+    w = conn.execute(
+        "SELECT COALESCE(SUM(total_min),0) FROM weekly_archive WHERE user_id=?", (uid,)
+    ).fetchone()[0]
+    return int(s) + int(w)
+
+
+def perform_merge(conn, target_uid, source_uids, canonical, dry_run) -> None:
+    ids = list(dict.fromkeys([target_uid, *source_uids]))
+    placeholders = ",".join("?" * len(ids))
+    conn.execute("BEGIN")
+    for table in TABLES:
+        n = conn.execute(
+            f"UPDATE {table} SET user_id=?, username=? WHERE user_id IN ({placeholders})",
+            (target_uid, canonical, *ids),
+        ).rowcount
+        log(f"{table}: {n} rows now under {target_uid} as {canonical!r}")
+    wm = merge_dupes(conn, "weekly_archive", ("user_id", "week_label"))
+    am = merge_dupes(conn, "activity_archive", ("user_id", "week_label", "activity"))
+    log(f"weekly_archive duplicates merged: {wm}; activity_archive duplicates merged: {am}")
+    if dry_run:
+        conn.rollback()
+        log("dry run: rolled back, no changes written")
+    else:
+        conn.commit()
+        log("committed")
+
+
+def do_list(conn: sqlite3.Connection) -> None:
+    """Print every account (user_id) with its hours and the display names seen,
+    and call out any display name shared by more than one account."""
+    rows = conn.execute(
+        """
+        SELECT user_id, GROUP_CONCAT(DISTINCT username) FROM (
+            SELECT user_id, username FROM sessions
+            UNION SELECT user_id, username FROM weekly_archive
+            UNION SELECT user_id, username FROM activity_archive
+        ) GROUP BY user_id
+        """
+    ).fetchall()
+    data = [(uid, total_minutes(conn, uid), names or "") for uid, names in rows]
+    log("accounts (user_id | total | display names seen):")
+    for uid, mins, names in sorted(data, key=lambda r: -r[1]):
+        log(f"  {uid} | {mins / 60:.1f}h | {names}")
+    from collections import defaultdict
+
+    by_name: dict[str, set[str]] = defaultdict(set)
+    for uid, _, names in data:
+        for nm in names.split(","):
+            if nm:
+                by_name[nm].add(uid)
+    dups = {nm: us for nm, us in by_name.items() if len(us) > 1}
+    if dups:
+        log("duplicate display names (one name, several accounts):")
+        for nm, us in dups.items():
+            log(f"  {nm!r}: user_ids {sorted(us)}  ->  merge with --dedupe-name {nm}")
+    else:
+        log("no duplicate display names found")
+
+
+def do_dedupe_name(conn: sqlite3.Connection, name: str, dry_run: bool) -> None:
+    """Merge every account sharing this display name into the one with the most
+    hours. The right tool when two leaderboard rows show the same name (so they
+    cannot be told apart by name) but are one person."""
+    uids = uids_for_name(conn, name)
+    if len(uids) < 2:
+        log(f"dedupe {name!r}: maps to {len(uids)} account(s), nothing to merge")
+        return
+    totals = {u: total_minutes(conn, u) for u in uids}
+    target = max(uids, key=lambda u: totals[u])
+    sources = [u for u in uids if u != target]
+    log(f"dedupe {name!r}: " + ", ".join(f"{u}={totals[u] / 60:.1f}h" for u in uids))
+    log(f"dedupe {name!r}: keeping {target}, folding {sources} into it")
+    perform_merge(conn, target, sources, name, dry_run)
+
+
+def do_dedupe_all(conn: sqlite3.Connection, dry_run: bool) -> None:
+    """Auto-dedupe the all-time leaderboard. For every display name shared by
+    more than one user_id, fold the smaller accounts (by all-time hours) into
+    the one with the most hours, overriding the smaller accounts' user_id."""
+    from collections import defaultdict
+
+    rows = conn.execute(
+        """
+        SELECT user_id, GROUP_CONCAT(DISTINCT username) FROM (
+            SELECT user_id, username FROM sessions
+            UNION SELECT user_id, username FROM weekly_archive
+            UNION SELECT user_id, username FROM activity_archive
+        ) GROUP BY user_id
+        """
+    ).fetchall()
+    by_name: dict[str, set[str]] = defaultdict(set)
+    for uid, names in rows:
+        for nm in (names or "").split(","):
+            if nm:
+                by_name[nm].add(uid)
+    dups = {nm: us for nm, us in by_name.items() if len(us) > 1}
+    if not dups:
+        log("dedupe-all: no display name maps to more than one account, nothing to do")
+        return
+
+    # Plan from the clean read state, then apply in one transaction.
+    plans = []
+    for nm, uids in dups.items():
+        totals = {u: total_minutes(conn, u) for u in uids}
+        keeper = max(uids, key=lambda u: totals[u])
+        losers = [u for u in uids if u != keeper]
+        plans.append((nm, keeper, losers, totals))
+
+    conn.execute("BEGIN")
+    folded = 0
+    for nm, keeper, losers, totals in plans:
+        ranked = ", ".join(f"{u}={totals[u] / 60:.1f}h" for u in sorted(totals, key=lambda u: -totals[u]))
+        log(f"dedupe-all {nm!r}: {ranked}")
+        log(f"dedupe-all {nm!r}: keeping {keeper}, overriding {losers} -> {keeper}")
+        ids = list(dict.fromkeys([keeper, *losers]))
+        placeholders = ",".join("?" * len(ids))
+        for table in TABLES:
+            conn.execute(
+                f"UPDATE {table} SET user_id=?, username=? WHERE user_id IN ({placeholders})",
+                (keeper, nm, *ids),
+            )
+        folded += len(losers)
+    wm = merge_dupes(conn, "weekly_archive", ("user_id", "week_label"))
+    am = merge_dupes(conn, "activity_archive", ("user_id", "week_label", "activity"))
+    log(f"dedupe-all: folded {folded} duplicate account(s); merged {wm} weekly + {am} activity rows")
+    if dry_run:
+        conn.rollback()
+        log("dry run: rolled back, no changes written")
+    else:
+        conn.commit()
+        log("committed")
+
+
 def main() -> int:
     p = argparse.ArgumentParser(description="Merge one ClockBot user's rows into another, by user_id.")
     p.add_argument("db", type=Path)
@@ -151,11 +300,15 @@ def main() -> int:
     p.add_argument("--from-id")
     p.add_argument("--from-name")
     p.add_argument("--name", help="Canonical display name to set on the merged account.")
+    p.add_argument("--dedupe-name", help="Merge every account sharing this display name into the one with the most hours.")
+    p.add_argument("--dedupe-all", action="store_true", help="Auto-fold every duplicate-display-name account in the leaderboard into its largest account.")
+    p.add_argument("--list", action="store_true", help="List accounts and any duplicate display names, then exit.")
     p.add_argument("--dry-run", action="store_true")
     args = p.parse_args()
 
-    if not (args.into_id or args.into_name) or not (args.from_id or args.from_name):
-        log("nothing to do: need a target (--into-id/--into-name) and a source (--from-id/--from-name)")
+    has_pair = (args.into_id or args.into_name) and (args.from_id or args.from_name)
+    if not args.list and not args.dedupe_name and not args.dedupe_all and not has_pair:
+        log("nothing to do: pass --list, --dedupe-all, --dedupe-name NAME, or both --into-* and --from-*")
         return 0
     if not args.db.exists():
         log(f"database not found at {args.db}, skipping")
@@ -165,6 +318,16 @@ def main() -> int:
     try:
         conn.execute("PRAGMA foreign_keys = ON")
         ensure_metadata(conn)
+
+        if args.list:
+            do_list(conn)
+            return 0
+        if args.dedupe_all:
+            do_dedupe_all(conn, args.dry_run)
+            return 0
+        if args.dedupe_name:
+            do_dedupe_name(conn, args.dedupe_name, args.dry_run)
+            return 0
 
         target_uid, t_status = resolve(conn, "into", args.into_id, args.into_name)
         source_uid, s_status = resolve(conn, "from", args.from_id, args.from_name)


### PR DESCRIPTION
## What this does

Adds an automatic leaderboard repair to `merge_clock_user.py`. The all-time leaderboard groups by `user_id`, so one person with two Discord accounts under the same display name shows as two rows (your screenshot: **Thirsty 798h** and **Thirsty 118h**).

`--dedupe-all`:
1. scans the all-time leaderboard,
2. finds every display name mapped to more than one `user_id`,
3. folds the smaller account(s) by total hours into the largest one, **overriding the smaller account's `user_id`** with the larger one's, and
4. merges the resulting duplicate archive rows.

For your data it produces one **Thirsty = 916h** (798 + 118), with Bimodality and ajith untouched and the total preserved. Tested end to end, including `--dry-run` and an idempotent re-run (second pass finds nothing).

Also included, from the same tool: `--dedupe-name <name>` (one display name) and `--list` (show every account, its hours, and any duplicate names).

## How to run it

One-off against the live container, no reboot:

```bash
docker exec <clock-container> python3 /usr/local/bin/merge_clock_user.py /data/clock.db --list        # see the ids
docker exec <clock-container> python3 /usr/local/bin/merge_clock_user.py /data/clock.db --dedupe-all --dry-run
docker exec <clock-container> python3 /usr/local/bin/merge_clock_user.py /data/clock.db --dedupe-all
```

Or set `CLOCK_MERGE_DEDUPE_ALL=1` and restart once (then unset it).

## Safety

- Keyed on `user_id`; **always exits 0** so it can never crash-loop the bot; the entrypoint guards it too.
- Transactional, idempotent (a second run finds no duplicates), `--dry-run` previews.
- One caveat by design: `--dedupe-all` assumes two accounts sharing a display name are the same person. `--list` / `--dry-run` show exactly which ids merge before you commit.
