### PR TITLE
Add /clock user: per-user activity profile card

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,10 +11,22 @@ Clock in/out tracker for Discord. SQLite-backed, weekly resets, all-time leaderb
 /clock who                                    — who's working right now
 /clock leaderboard                            — weekly + all-time rankings (alias: /clock lb)
 /clock stats                                  — weekly activity breakdown (top activities + per-person)
+/clock user [@user|name]                      — PNG activity profile card (alias: /clock me)
 /clock rename <old> > <new>                   — rename and merge one of your activities
 /clock chart [weeks] [totals|cumulative|both] — PNG line chart of top 5 weekly hours
 /clock help                                   — command list
 ```
+
+### `/clock user` details
+
+Renders a per-user profile card showing what that person spends time on:
+total / this-week / best-week / active-weeks stats, an all-time activity
+breakdown with share percentages, a 12-week trend, and the live session if
+they are clocked in right now.
+
+- `/clock user` or `/clock me` — your own profile
+- `/clock user @mention` — profile of the mentioned user
+- `/clock user <name>` — lookup by tracked username (case-insensitive, prefix works)
 
 ### `/clock chart` details
 

--- a/src/chart.rs
+++ b/src/chart.rs
@@ -1,4 +1,4 @@
-use crate::db::{ChartData, LeaderboardEntry};
+use crate::db::{ChartData, LeaderboardEntry, UserProfile};
 use plotters::prelude::*;
 use plotters::style::text_anchor::{HPos, Pos, VPos};
 
@@ -31,8 +31,13 @@ const ALLTIME_ACCENT: RGBColor = RGBColor(0xa7, 0x8b, 0xfa);
 const RANK_GOLD: RGBColor = RGBColor(0xf5, 0xc5, 0x42);
 const RANK_SILVER: RGBColor = RGBColor(0xb2, 0xc8, 0xff);
 const RANK_BRONZE: RGBColor = RGBColor(0xe0, 0x8a, 0x3e);
+const LIVE_GREEN: RGBColor = RGBColor(0x2e, 0xcc, 0x71);
 const MAX_LEADERBOARD_NAME_CHARS: usize = 18;
 const MAX_CHART_LEGEND_CHARS: usize = 14;
+const MAX_PROFILE_ACTIVITIES: usize = 6;
+const MAX_PROFILE_ACTIVITY_CHARS: usize = 18;
+const MAX_PROFILE_TITLE_CHARS: usize = 14;
+const MAX_PROFILE_STATUS_CHARS: usize = 12;
 const LEADERBOARD_CONTENT_BOTTOM_Y: i32 = 790;
 const LEADERBOARD_MIN_ALLTIME_HEIGHT: i32 = 220;
 
@@ -389,6 +394,445 @@ where
     Ok(())
 }
 
+/// Render a per-user activity profile card.
+/// Layout: header with live status, four stat tiles, an all-time activity
+/// breakdown, and a weekly trend strip. Image height adapts to the number
+/// of activity rows.
+pub fn render_user_card(profile: &UserProfile) -> anyhow::Result<Vec<u8>> {
+    let width: u32 = 1120;
+    let left: i32 = 56;
+    let section_w: i32 = 1008;
+
+    let tiles_top: i32 = 160;
+    let tiles_h: i32 = 96;
+
+    let shown = profile.top_activities.len().min(MAX_PROFILE_ACTIVITIES);
+    let overflow_count = profile.top_activities.len().saturating_sub(shown);
+    let act_top = tiles_top + tiles_h + 22;
+    let act_rows = shown.max(1) as i32; // one row minimum for the empty message
+    let act_h = 70 + act_rows * 54 + if overflow_count > 0 { 40 } else { 0 } + 14;
+
+    let trend_top = act_top + act_h + 22;
+    let trend_h: i32 = 208;
+
+    let card_bottom = trend_top + trend_h + 26;
+    let footer_y = card_bottom + 34;
+    let height = (footer_y + 26) as u32;
+
+    let mut pixel_buf = vec![0u8; (width * height * 3) as usize];
+    {
+        let root = BitMapBackend::with_buffer(&mut pixel_buf, (width, height)).into_drawing_area();
+        root.fill(&BG)
+            .map_err(|e| anyhow::anyhow!("fill error: {:?}", e))?;
+
+        root.draw(&Rectangle::new(
+            [(24, 20), (1096, card_bottom)],
+            ShapeStyle::from(&PANEL_BG).filled(),
+        ))
+        .map_err(|e| anyhow::anyhow!("draw card bg: {:?}", e))?;
+        root.draw(&Rectangle::new(
+            [(24, 20), (1096, card_bottom)],
+            ShapeStyle::from(&PANEL_STROKE).stroke_width(1),
+        ))
+        .map_err(|e| anyhow::anyhow!("draw card border: {:?}", e))?;
+
+        // ── Header ────────────────────────────────────────────
+        root.draw(&Text::new(
+            truncate_name(&profile.username, MAX_PROFILE_TITLE_CHARS),
+            (left, 56),
+            ("sans-serif", 42).into_font().color(&FG),
+        ))
+        .map_err(|e| anyhow::anyhow!("draw title: {:?}", e))?;
+
+        root.draw(&Text::new(
+            "activity profile · all time",
+            (left, 104),
+            ("sans-serif", 20).into_font().color(&MUTED),
+        ))
+        .map_err(|e| anyhow::anyhow!("draw subtitle: {:?}", e))?;
+
+        let (status_text, status_color) = match &profile.active_session {
+            Some((activity, elapsed)) => (
+                format!(
+                    "● {} · {}",
+                    truncate_name(activity, MAX_PROFILE_STATUS_CHARS),
+                    format_duration(*elapsed)
+                ),
+                LIVE_GREEN,
+            ),
+            None => ("○ not clocked in".to_string(), MUTED),
+        };
+        root.draw(&Text::new(
+            status_text,
+            (left + section_w, 70),
+            ("sans-serif", 22)
+                .into_font()
+                .color(&status_color)
+                .pos(Pos::new(HPos::Right, VPos::Center)),
+        ))
+        .map_err(|e| anyhow::anyhow!("draw status: {:?}", e))?;
+
+        root.draw(&PathElement::new(
+            vec![(left, 134), (left + section_w, 134)],
+            PANEL_STROKE.mix(0.85).stroke_width(1),
+        ))
+        .map_err(|e| anyhow::anyhow!("draw header divider: {:?}", e))?;
+
+        // ── Stat tiles ────────────────────────────────────────
+        let best_label = match &profile.best_week {
+            Some((label, _)) => format!("best week · {}", short_week_label(label)),
+            None => "best week".to_string(),
+        };
+        let best_value = match &profile.best_week {
+            Some((_, minutes)) => format_duration(*minutes),
+            None => "—".to_string(),
+        };
+        let tiles: [(String, String); 4] = [
+            ("total".to_string(), format_duration(profile.total_minutes)),
+            (
+                "this week".to_string(),
+                format_duration(profile.current_week_minutes),
+            ),
+            (best_label, best_value),
+            (
+                "active weeks".to_string(),
+                format!("{}", profile.active_weeks),
+            ),
+        ];
+        const TILE_W: i32 = 240;
+        const TILE_GAP: i32 = 16; // 4 * 240 + 3 * 16 == section_w
+        for (i, (label, value)) in tiles.iter().enumerate() {
+            let tx = left + i as i32 * (TILE_W + TILE_GAP);
+            root.draw(&Rectangle::new(
+                [(tx, tiles_top), (tx + TILE_W, tiles_top + tiles_h)],
+                ShapeStyle::from(&PANEL_BG.mix(0.8)).filled(),
+            ))
+            .map_err(|e| anyhow::anyhow!("draw tile bg: {:?}", e))?;
+            root.draw(&Rectangle::new(
+                [(tx, tiles_top), (tx + TILE_W, tiles_top + tiles_h)],
+                ShapeStyle::from(&PANEL_STROKE).stroke_width(1),
+            ))
+            .map_err(|e| anyhow::anyhow!("draw tile border: {:?}", e))?;
+            root.draw(&Text::new(
+                label.clone(),
+                (tx + 18, tiles_top + 18),
+                ("sans-serif", 17).into_font().color(&MUTED),
+            ))
+            .map_err(|e| anyhow::anyhow!("draw tile label: {:?}", e))?;
+            root.draw(&Text::new(
+                value.clone(),
+                (tx + 18, tiles_top + 46),
+                ("sans-serif", 30).into_font().color(&FG),
+            ))
+            .map_err(|e| anyhow::anyhow!("draw tile value: {:?}", e))?;
+        }
+
+        draw_profile_activities(
+            &root,
+            left,
+            act_top,
+            section_w,
+            act_h,
+            profile,
+            shown,
+            overflow_count,
+        )?;
+        draw_profile_trend(&root, left, trend_top, section_w, trend_h, profile)?;
+
+        root.draw(&Text::new(
+            "Tracked with /clock · Europe/Zurich",
+            (left, footer_y),
+            ("sans-serif", 18).into_font().color(&MUTED),
+        ))
+        .map_err(|e| anyhow::anyhow!("draw footer: {:?}", e))?;
+
+        root.present()
+            .map_err(|e| anyhow::anyhow!("present error: {:?}", e))?;
+    }
+
+    let img = image::RgbImage::from_raw(width, height, pixel_buf)
+        .ok_or_else(|| anyhow::anyhow!("failed to create RGB image from pixel buffer"))?;
+    let mut png_bytes: Vec<u8> = Vec::new();
+    image::DynamicImage::ImageRgb8(img)
+        .write_to(
+            &mut std::io::Cursor::new(&mut png_bytes),
+            image::ImageFormat::Png,
+        )
+        .map_err(|e| anyhow::anyhow!("PNG encode error: {}", e))?;
+
+    Ok(png_bytes)
+}
+
+#[allow(clippy::too_many_arguments)]
+fn draw_profile_activities<DB>(
+    area: &DrawingArea<DB, plotters::coord::Shift>,
+    x: i32,
+    y: i32,
+    w: i32,
+    h: i32,
+    profile: &UserProfile,
+    shown: usize,
+    overflow_count: usize,
+) -> anyhow::Result<()>
+where
+    DB: DrawingBackend,
+    DB::ErrorType: std::error::Error + Send + Sync + 'static,
+{
+    area.draw(&Rectangle::new(
+        [(x, y), (x + w, y + h)],
+        ShapeStyle::from(&PANEL_BG.mix(0.8)).filled(),
+    ))
+    .map_err(|e| anyhow::anyhow!("draw activities bg: {:?}", e))?;
+    area.draw(&Rectangle::new(
+        [(x, y), (x + w, y + h)],
+        ShapeStyle::from(&ALLTIME_ACCENT.mix(0.42)).stroke_width(1),
+    ))
+    .map_err(|e| anyhow::anyhow!("draw activities border: {:?}", e))?;
+
+    area.draw(&Text::new(
+        "what they do",
+        (x + 24, y + 26),
+        ("sans-serif", 26).into_font().color(&FG),
+    ))
+    .map_err(|e| anyhow::anyhow!("draw activities title: {:?}", e))?;
+
+    area.draw(&Text::new(
+        format!("{} activities", profile.top_activities.len()),
+        (x + w - 24, y + 40),
+        ("sans-serif", 19)
+            .into_font()
+            .color(&MUTED)
+            .pos(Pos::new(HPos::Right, VPos::Center)),
+    ))
+    .map_err(|e| anyhow::anyhow!("draw activities count: {:?}", e))?;
+
+    area.draw(&PathElement::new(
+        vec![(x + 24, y + 58), (x + w - 24, y + 58)],
+        PANEL_STROKE.mix(0.75).stroke_width(1),
+    ))
+    .map_err(|e| anyhow::anyhow!("draw activities divider: {:?}", e))?;
+
+    if shown == 0 {
+        area.draw(&Text::new(
+            "No completed sessions yet.",
+            (x + 24, y + 84),
+            ("sans-serif", 24).into_font().color(&MUTED),
+        ))
+        .map_err(|e| anyhow::anyhow!("draw activities empty: {:?}", e))?;
+        return Ok(());
+    }
+
+    const ROW_HEIGHT: i32 = 54;
+    const BAR_LEFT_OFFSET: i32 = 460;
+    const BAR_MAX_WIDTH: i64 = 300;
+    const BAR_HEIGHT: i32 = 14;
+    let max_minutes = profile
+        .top_activities
+        .first()
+        .map(|(_, m)| *m)
+        .unwrap_or(1)
+        .max(1);
+    let total = profile.total_minutes.max(1);
+
+    for (idx, (activity, minutes)) in profile.top_activities.iter().take(shown).enumerate() {
+        let row_y = y + 70 + idx as i32 * ROW_HEIGHT;
+
+        if idx > 0 {
+            area.draw(&PathElement::new(
+                vec![(x + 24, row_y - 6), (x + w - 24, row_y - 6)],
+                PANEL_STROKE.mix(0.45).stroke_width(1),
+            ))
+            .map_err(|e| anyhow::anyhow!("draw activity row divider: {:?}", e))?;
+        }
+
+        area.draw(&Text::new(
+            truncate_name(activity, MAX_PROFILE_ACTIVITY_CHARS),
+            (x + 24, row_y + 12),
+            ("sans-serif", 25).into_font().color(&FG),
+        ))
+        .map_err(|e| anyhow::anyhow!("draw activity name: {:?}", e))?;
+
+        let bar_left = x + BAR_LEFT_OFFSET;
+        let bar_top = row_y + 19;
+        let fill = ((minutes * BAR_MAX_WIDTH) / max_minutes).max(2) as i32;
+        area.draw(&Rectangle::new(
+            [
+                (bar_left, bar_top),
+                (bar_left + BAR_MAX_WIDTH as i32, bar_top + BAR_HEIGHT),
+            ],
+            ShapeStyle::from(&PANEL_STROKE.mix(0.9)).filled(),
+        ))
+        .map_err(|e| anyhow::anyhow!("draw activity bar bg: {:?}", e))?;
+        area.draw(&Rectangle::new(
+            [(bar_left, bar_top), (bar_left + fill, bar_top + BAR_HEIGHT)],
+            ShapeStyle::from(&ALLTIME_ACCENT.mix(0.8)).filled(),
+        ))
+        .map_err(|e| anyhow::anyhow!("draw activity bar fill: {:?}", e))?;
+
+        let pct = (minutes * 100 + total / 2) / total;
+        area.draw(&Text::new(
+            format!("{} · {}%", format_duration(*minutes), pct),
+            (x + w - 24, row_y + 26),
+            ("sans-serif", 24)
+                .into_font()
+                .color(&FG)
+                .pos(Pos::new(HPos::Right, VPos::Center)),
+        ))
+        .map_err(|e| anyhow::anyhow!("draw activity value: {:?}", e))?;
+    }
+
+    if overflow_count > 0 {
+        let rest_minutes: i64 = profile
+            .top_activities
+            .iter()
+            .skip(shown)
+            .map(|(_, m)| *m)
+            .sum();
+        let row_y = y + 70 + shown as i32 * ROW_HEIGHT;
+        area.draw(&Text::new(
+            format!(
+                "+ {} more · {}",
+                overflow_count,
+                format_duration(rest_minutes)
+            ),
+            (x + 24, row_y + 8),
+            ("sans-serif", 20).into_font().color(&MUTED),
+        ))
+        .map_err(|e| anyhow::anyhow!("draw activity overflow: {:?}", e))?;
+    }
+
+    Ok(())
+}
+
+fn draw_profile_trend<DB>(
+    area: &DrawingArea<DB, plotters::coord::Shift>,
+    x: i32,
+    y: i32,
+    w: i32,
+    h: i32,
+    profile: &UserProfile,
+) -> anyhow::Result<()>
+where
+    DB: DrawingBackend,
+    DB::ErrorType: std::error::Error + Send + Sync + 'static,
+{
+    area.draw(&Rectangle::new(
+        [(x, y), (x + w, y + h)],
+        ShapeStyle::from(&PANEL_BG.mix(0.8)).filled(),
+    ))
+    .map_err(|e| anyhow::anyhow!("draw trend bg: {:?}", e))?;
+    area.draw(&Rectangle::new(
+        [(x, y), (x + w, y + h)],
+        ShapeStyle::from(&WEEK_ACCENT.mix(0.42)).stroke_width(1),
+    ))
+    .map_err(|e| anyhow::anyhow!("draw trend border: {:?}", e))?;
+
+    let n = profile.week_labels.len().max(1);
+    area.draw(&Text::new(
+        format!("last {} weeks", n),
+        (x + 24, y + 26),
+        ("sans-serif", 26).into_font().color(&FG),
+    ))
+    .map_err(|e| anyhow::anyhow!("draw trend title: {:?}", e))?;
+
+    let max_minutes = profile.weekly_minutes.iter().copied().max().unwrap_or(0);
+    let right_text = if max_minutes > 0 {
+        format!("peak · {}", format_duration(max_minutes))
+    } else {
+        "no data in window".to_string()
+    };
+    area.draw(&Text::new(
+        right_text,
+        (x + w - 24, y + 40),
+        ("sans-serif", 19)
+            .into_font()
+            .color(&MUTED)
+            .pos(Pos::new(HPos::Right, VPos::Center)),
+    ))
+    .map_err(|e| anyhow::anyhow!("draw trend peak: {:?}", e))?;
+
+    area.draw(&PathElement::new(
+        vec![(x + 24, y + 58), (x + w - 24, y + 58)],
+        PANEL_STROKE.mix(0.75).stroke_width(1),
+    ))
+    .map_err(|e| anyhow::anyhow!("draw trend divider: {:?}", e))?;
+
+    let inner_left = x + 24;
+    let inner_w = w - 48;
+    let bars_bottom = y + 162;
+    // Short enough that the peak label above the tallest bar clears the
+    // section divider at y + 58.
+    let bars_max_h: i32 = 72;
+    let slot = inner_w / n as i32;
+    let bar_w = (slot * 3 / 5).max(2);
+    let scale_max = max_minutes.max(1);
+
+    let mut peak_center: Option<(i32, i32)> = None;
+    for (i, minutes) in profile.weekly_minutes.iter().enumerate() {
+        let bx = inner_left + i as i32 * slot + (slot - bar_w) / 2;
+        let is_current = i == n - 1;
+        if *minutes > 0 {
+            let bar_h = ((*minutes * bars_max_h as i64) / scale_max).max(3) as i32;
+            let color = if is_current {
+                WEEK_ACCENT.mix(1.0)
+            } else {
+                WEEK_ACCENT.mix(0.55)
+            };
+            area.draw(&Rectangle::new(
+                [(bx, bars_bottom - bar_h), (bx + bar_w, bars_bottom)],
+                ShapeStyle::from(&color).filled(),
+            ))
+            .map_err(|e| anyhow::anyhow!("draw trend bar: {:?}", e))?;
+            if *minutes == max_minutes && peak_center.is_none() {
+                peak_center = Some((bx + bar_w / 2, bars_bottom - bar_h));
+            }
+        } else {
+            area.draw(&Rectangle::new(
+                [(bx, bars_bottom - 2), (bx + bar_w, bars_bottom)],
+                ShapeStyle::from(&MUTED.mix(0.3)).filled(),
+            ))
+            .map_err(|e| anyhow::anyhow!("draw trend stub: {:?}", e))?;
+        }
+    }
+
+    area.draw(&PathElement::new(
+        vec![(inner_left, bars_bottom + 1), (x + w - 24, bars_bottom + 1)],
+        PANEL_STROKE.mix(0.9).stroke_width(1),
+    ))
+    .map_err(|e| anyhow::anyhow!("draw trend baseline: {:?}", e))?;
+
+    if let Some((cx, top)) = peak_center {
+        area.draw(&Text::new(
+            format_duration(max_minutes),
+            (cx, top - 16),
+            ("sans-serif", 16)
+                .into_font()
+                .color(&MUTED)
+                .pos(Pos::new(HPos::Center, VPos::Center)),
+        ))
+        .map_err(|e| anyhow::anyhow!("draw trend peak label: {:?}", e))?;
+    }
+
+    let step = n.div_ceil(6).max(1);
+    for (i, label) in profile.week_labels.iter().enumerate() {
+        if i % step != 0 && i != n - 1 {
+            continue;
+        }
+        let cx = inner_left + i as i32 * slot + slot / 2;
+        area.draw(&Text::new(
+            short_week_label(label),
+            (cx, bars_bottom + 16),
+            ("sans-serif", 16)
+                .into_font()
+                .color(&MUTED)
+                .pos(Pos::new(HPos::Center, VPos::Center)),
+        ))
+        .map_err(|e| anyhow::anyhow!("draw trend label: {:?}", e))?;
+    }
+
+    Ok(())
+}
+
 fn rank_label(idx: usize) -> String {
     match idx {
         0 => "1st".to_string(),
@@ -698,6 +1142,56 @@ mod tests {
             users: vec![],
         };
         assert!(render_chart(&data, ChartMode::Totals).is_err());
+    }
+
+    fn sample_profile() -> crate::db::UserProfile {
+        crate::db::UserProfile {
+            username: "Alice".to_string(),
+            total_minutes: 1234,
+            current_week_minutes: 230,
+            active_weeks: 7,
+            best_week: Some(("KW15/2026".to_string(), 480)),
+            top_activities: vec![
+                ("writing".to_string(), 400),
+                ("reading".to_string(), 300),
+                ("thesis".to_string(), 200),
+                ("review".to_string(), 120),
+                ("meeting".to_string(), 90),
+                ("planning".to_string(), 60),
+                ("email".to_string(), 40),
+                ("misc".to_string(), 24),
+            ],
+            week_labels: (14..=25).map(|w| format!("KW{:02}/2026", w)).collect(),
+            weekly_minutes: vec![0, 60, 480, 120, 0, 90, 200, 44, 0, 0, 10, 230],
+            active_session: Some(("writing".to_string(), 42)),
+        }
+    }
+
+    #[test]
+    fn test_render_user_card_produces_png() {
+        register_test_font();
+        let profile = sample_profile();
+        let bytes = render_user_card(&profile).expect("render failed");
+        assert!(bytes.starts_with(b"\x89PNG\r\n\x1a\n"));
+        assert!(bytes.len() > 10_000, "user card PNG seems too small");
+    }
+
+    #[test]
+    fn test_render_user_card_empty_profile() {
+        register_test_font();
+        let profile = crate::db::UserProfile {
+            username: "Alice".to_string(),
+            total_minutes: 0,
+            current_week_minutes: 0,
+            active_weeks: 0,
+            best_week: None,
+            top_activities: vec![],
+            week_labels: (14..=25).map(|w| format!("KW{:02}/2026", w)).collect(),
+            weekly_minutes: vec![0; 12],
+            active_session: None,
+        };
+        let bytes = render_user_card(&profile).expect("render failed");
+        assert!(bytes.starts_with(b"\x89PNG\r\n\x1a\n"));
     }
 
     #[test]

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -11,6 +11,7 @@ const HELP: &str = r#"**Commands**
 `/clock leaderboard` — weekly + all-time
 `/clock stats` — activity breakdown
 `/clock alltime` — all-time activity stats for everyone
+`/clock user [@user|name]` — activity profile card (`/clock me` for yours)
 `/clock rename <old> > <new>` — rename + merge activity
 `/clock chart [weeks] [totals|cumulative|both]` — line chart of top 5 weekly hours
 `/clock help`"#;
@@ -74,6 +75,9 @@ pub async fn handle_command(ctx: &Context, msg: &Message, db: &Arc<Db>) {
         handle_stats(ctx, msg, db).await;
     } else if rest == "alltime" || rest == "all-time" || rest == "at" {
         handle_alltime(ctx, msg, db).await;
+    } else if rest == "me" || rest == "user" || rest.starts_with("user ") {
+        let args = rest.strip_prefix("user").map(str::trim).unwrap_or("");
+        handle_user(ctx, msg, db, args).await;
     } else if rest.starts_with("rename ") {
         let args = rest.strip_prefix("rename ").unwrap().trim();
         handle_rename(ctx, msg, db, args).await;
@@ -633,6 +637,185 @@ async fn handle_alltime(ctx: &Context, msg: &Message, db: &Arc<Db>) {
             CreateMessage::new().add_embeds(vec![embed1, embed2]),
         )
         .await;
+}
+
+const PROFILE_TREND_WEEKS: u32 = 12;
+
+/// Extract the user id from mention syntax (`<@123>` / `<@!123>`).
+/// Returns None unless the whole argument is a single mention.
+fn parse_mention_arg(args: &str) -> Option<&str> {
+    let inner = args.strip_prefix("<@")?.strip_suffix('>')?;
+    let inner = inner.strip_prefix('!').unwrap_or(inner);
+    (!inner.is_empty() && inner.bytes().all(|b| b.is_ascii_digit())).then_some(inner)
+}
+
+async fn handle_user(ctx: &Context, msg: &Message, db: &Arc<Db>, args: &str) {
+    let _ = msg.channel_id.broadcast_typing(&ctx.http).await;
+
+    // Resolve the target from the command text only — msg.mentions also
+    // contains the replied-to author when someone replies with a ping, which
+    // must not hijack the target. Display name from Discord when we have it;
+    // name lookups keep the most recent stored username from the profile.
+    let resolved: Result<Option<(String, Option<String>)>, anyhow::Error> =
+        if let Some(mention_id) = parse_mention_arg(args) {
+            let display = msg
+                .mentions
+                .iter()
+                .find(|u| u.id.to_string() == mention_id)
+                .map(|u| u.display_name().to_string());
+            Ok(Some((mention_id.to_string(), display)))
+        } else if !args.is_empty() {
+            db.resolve_user(args)
+                .map(|hit| hit.map(|(user_id, _)| (user_id, None)))
+        } else {
+            Ok(Some((
+                msg.author.id.to_string(),
+                Some(msg.author.display_name().to_string()),
+            )))
+        };
+
+    let target = match resolved {
+        Ok(t) => t,
+        Err(e) => {
+            let embed = CreateEmbed::new()
+                .color(COLOR_PINK)
+                .title("profile unavailable")
+                .description(format!("{}", e))
+                .footer(CreateEmbedFooter::new(swiss_timestamp()));
+            let _ = msg
+                .channel_id
+                .send_message(&ctx.http, CreateMessage::new().embed(embed))
+                .await;
+            return;
+        }
+    };
+
+    let Some((user_id, display_override)) = target else {
+        let embed = CreateEmbed::new()
+            .color(COLOR_DARK)
+            .title("user not found")
+            .description(format!("No tracked time found for **{}**.", args))
+            .footer(CreateEmbedFooter::new(swiss_timestamp()));
+        let _ = msg
+            .channel_id
+            .send_message(&ctx.http, CreateMessage::new().embed(embed))
+            .await;
+        return;
+    };
+
+    let display_name = display_override.clone().unwrap_or_else(|| {
+        if args.is_empty() { "you".to_string() } else { args.to_string() }
+    });
+    let profile = match db.user_profile(&user_id, PROFILE_TREND_WEEKS) {
+        Ok(Some(mut profile)) => {
+            if let Some(name) = display_override {
+                profile.username = name;
+            }
+            profile
+        }
+        Ok(None) => {
+            let embed = CreateEmbed::new()
+                .color(COLOR_DARK)
+                .title(format!("profile · {}", display_name))
+                .description("No tracked time yet. `/clock in <activity>` to start.")
+                .footer(CreateEmbedFooter::new(swiss_timestamp()));
+            let _ = msg
+                .channel_id
+                .send_message(&ctx.http, CreateMessage::new().embed(embed))
+                .await;
+            return;
+        }
+        Err(e) => {
+            let embed = CreateEmbed::new()
+                .color(COLOR_PINK)
+                .title("profile unavailable")
+                .description(format!("{}", e))
+                .footer(CreateEmbedFooter::new(swiss_timestamp()));
+            let _ = msg
+                .channel_id
+                .send_message(&ctx.http, CreateMessage::new().embed(embed))
+                .await;
+            return;
+        }
+    };
+
+    match crate::chart::render_user_card(&profile) {
+        Ok(png_bytes) => {
+            let mut desc = format!(
+                "{} all time · {} this week",
+                format_duration(profile.total_minutes),
+                format_duration(profile.current_week_minutes),
+            );
+            if let Some((activity, elapsed)) = &profile.active_session {
+                desc += &format!(
+                    "\nworking on {} for {}",
+                    activity,
+                    format_duration(*elapsed)
+                );
+            }
+            let embed = CreateEmbed::new()
+                .color(COLOR_VIOLET)
+                .title(format!("profile · {}", profile.username))
+                .description(desc)
+                .image("attachment://profile.png")
+                .footer(CreateEmbedFooter::new(swiss_timestamp()));
+
+            let attachment = CreateAttachment::bytes(png_bytes, "profile.png");
+            let _ = msg
+                .channel_id
+                .send_message(
+                    &ctx.http,
+                    CreateMessage::new().embed(embed).add_file(attachment),
+                )
+                .await;
+        }
+        Err(e) => {
+            // Text fallback mirroring the card's content.
+            let mut desc = format!(
+                "```\n  {} total  ·  {} this week  ·  {} active weeks\n```\n",
+                format_duration(profile.total_minutes),
+                format_duration(profile.current_week_minutes),
+                profile.active_weeks,
+            );
+            if let Some((label, minutes)) = &profile.best_week {
+                desc += &format!("best week · {} ({})\n", label, format_duration(*minutes));
+            }
+            if let Some((activity, elapsed)) = &profile.active_session {
+                desc += &format!("now · {} ({})\n", activity, format_duration(*elapsed));
+            }
+            desc += "\n";
+            let max_minutes = profile
+                .top_activities
+                .first()
+                .map(|(_, m)| *m)
+                .unwrap_or(1);
+            for (activity, minutes) in profile.top_activities.iter().take(8) {
+                desc += &format!(
+                    "`{}` {} — {}\n",
+                    make_bar(*minutes, max_minutes),
+                    activity,
+                    format_duration(*minutes)
+                );
+            }
+
+            let mut full_desc = format!("Fallback view · {}\n\n{}", e, desc);
+            const MAX_EMBED_DESC_CHARS: usize = 4000;
+            if full_desc.chars().count() > MAX_EMBED_DESC_CHARS {
+                let keep = MAX_EMBED_DESC_CHARS.saturating_sub(16);
+                let truncated: String = full_desc.chars().take(keep).collect();
+                full_desc = format!("{truncated}\n… (truncated)");
+            }
+            let embed = CreateEmbed::new()
+                .color(COLOR_VIOLET)
+                .title(format!("profile · {}", profile.username))
+                .description(full_desc)
+                .footer(CreateEmbedFooter::new(swiss_timestamp()));
+            let _ = msg
+                .channel_id
+                .send_message(&ctx.http, CreateMessage::new().embed(embed))
+                .await;
+        }
+    }
 }
 
 async fn handle_rename(ctx: &Context, msg: &Message, db: &Arc<Db>, args: &str) {

--- a/src/db.rs
+++ b/src/db.rs
@@ -1,6 +1,6 @@
 use chrono::{Datelike, Duration, NaiveDate, NaiveDateTime, Utc};
 use chrono_tz::Europe::Zurich;
-use rusqlite::{Connection, params};
+use rusqlite::{Connection, OptionalExtension, params};
 use std::collections::HashMap;
 use std::path::Path;
 use std::sync::Mutex;
@@ -55,6 +55,26 @@ pub struct UserActivityEntry {
 pub struct UserWeeklyData {
     pub username: String,
     pub minutes_per_week: Vec<i64>,
+}
+
+#[derive(Debug)]
+pub struct UserProfile {
+    pub username: String,
+    /// All-time tracked minutes (live sessions + weekly archive).
+    pub total_minutes: i64,
+    pub current_week_minutes: i64,
+    /// Number of distinct weeks with tracked time (including the current one).
+    pub active_weeks: i64,
+    /// Highest-volume week: (week_label, minutes).
+    pub best_week: Option<(String, i64)>,
+    /// All-time per-activity totals, descending.
+    pub top_activities: Vec<(String, i64)>,
+    /// Trend window labels in chronological order (oldest first).
+    pub week_labels: Vec<String>,
+    /// Minutes per week aligned with `week_labels`.
+    pub weekly_minutes: Vec<i64>,
+    /// Currently running session: (activity, elapsed minutes).
+    pub active_session: Option<(String, i64)>,
 }
 
 #[derive(Debug)]
@@ -739,6 +759,204 @@ impl Db {
         Ok(ChartData { week_labels, users })
     }
 
+    /// Resolve a user by user_id or by username (case-insensitive exact match,
+    /// then prefix match) across live sessions and archives.
+    /// When one name maps to several accounts (pre-merge duplicates), the
+    /// account with the most tracked time wins.
+    /// Returns the matching (user_id, most recent username for that account).
+    pub fn resolve_user(&self, query: &str) -> anyhow::Result<Option<(String, String)>> {
+        let q = query.trim();
+        if q.is_empty() {
+            return Ok(None);
+        }
+        let conn = self.conn.lock().unwrap();
+
+        // Most recent record wins; live sessions take priority over archives.
+        const UNION: &str = "SELECT user_id, username, src, ord FROM (
+                SELECT user_id, username, 2 AS src, id AS ord FROM sessions
+                UNION ALL
+                SELECT user_id, username, 1 AS src, id AS ord FROM weekly_archive
+                UNION ALL
+                SELECT user_id, username, 0 AS src, id AS ord FROM activity_archive
+            )";
+
+        // Distinct matching accounts, each with its most recent username,
+        // in recency order.
+        let candidates_for = |sql: &str, param: &str| -> anyhow::Result<Vec<(String, String)>> {
+            let mut stmt = conn.prepare(sql)?;
+            let rows = stmt.query_map(params![param], |r| {
+                Ok((r.get::<_, String>(0)?, r.get::<_, String>(1)?))
+            })?;
+            let mut out: Vec<(String, String)> = Vec::new();
+            for (user_id, username) in rows.filter_map(|r| r.ok()) {
+                if !out.iter().any(|(uid, _)| *uid == user_id) {
+                    out.push((user_id, username));
+                }
+            }
+            Ok(out)
+        };
+
+        let exact = format!(
+            "{UNION} WHERE user_id = ?1 OR LOWER(username) = LOWER(?1)
+             ORDER BY src DESC, ord DESC"
+        );
+        let mut candidates = candidates_for(&exact, q)?;
+
+        if candidates.is_empty() {
+            let escaped = q
+                .replace('\\', "\\\\")
+                .replace('%', "\\%")
+                .replace('_', "\\_");
+            let prefix = format!(
+                "{UNION} WHERE LOWER(username) LIKE LOWER(?1) || '%' ESCAPE '\\'
+                 ORDER BY src DESC, ord DESC"
+            );
+            candidates = candidates_for(&prefix, &escaped)?;
+        }
+
+        if candidates.len() <= 1 {
+            return Ok(candidates.pop());
+        }
+
+        // Ambiguous name: prefer the account with the most tracked time
+        // (ties go to the most recently active candidate).
+        let mut best = (i64::MIN, 0usize);
+        for (i, (user_id, _)) in candidates.iter().enumerate() {
+            let total: i64 = conn.query_row(
+                "SELECT COALESCE((SELECT SUM(minutes) FROM sessions
+                                  WHERE user_id = ?1 AND ended_at IS NOT NULL), 0)
+                      + COALESCE((SELECT SUM(total_min) FROM weekly_archive
+                                  WHERE user_id = ?1), 0)",
+                params![user_id],
+                |r| r.get(0),
+            )?;
+            if total > best.0 {
+                best = (total, i);
+            }
+        }
+        Ok(Some(candidates.swap_remove(best.1)))
+    }
+
+    /// Build the all-time activity profile for one user, with a trailing
+    /// `weeks`-week trend window. Returns None if the user has no records.
+    pub fn user_profile(&self, user_id: &str, weeks: u32) -> anyhow::Result<Option<UserProfile>> {
+        let week_labels = generate_week_labels(weeks.max(1));
+        let current_week_label = swiss_week_label();
+        let monday = monday_of_current_week();
+        let now = now_ch();
+        let conn = self.conn.lock().unwrap();
+
+        // Most recent stored username; doubles as the existence check.
+        let username: Option<String> = conn
+            .query_row(
+                "SELECT username FROM (
+                    SELECT username, 2 AS src, id AS ord FROM sessions WHERE user_id = ?1
+                    UNION ALL
+                    SELECT username, 1 AS src, id AS ord FROM weekly_archive WHERE user_id = ?1
+                    UNION ALL
+                    SELECT username, 0 AS src, id AS ord FROM activity_archive WHERE user_id = ?1
+                 ) ORDER BY src DESC, ord DESC LIMIT 1",
+                params![user_id],
+                |r| r.get(0),
+            )
+            .optional()?;
+        let Some(username) = username else {
+            return Ok(None);
+        };
+
+        let live_total: i64 = conn.query_row(
+            "SELECT COALESCE(SUM(minutes),0) FROM sessions
+             WHERE user_id = ?1 AND ended_at IS NOT NULL",
+            params![user_id],
+            |r| r.get(0),
+        )?;
+        let archive_total: i64 = conn.query_row(
+            "SELECT COALESCE(SUM(total_min),0) FROM weekly_archive WHERE user_id = ?1",
+            params![user_id],
+            |r| r.get(0),
+        )?;
+
+        let current_week_minutes: i64 = conn.query_row(
+            "SELECT COALESCE(SUM(minutes),0) FROM sessions
+             WHERE user_id = ?1 AND ended_at IS NOT NULL AND ended_at >= ?2",
+            params![user_id, monday],
+            |r| r.get(0),
+        )?;
+
+        // Per-week totals over the full history (best week, active weeks, trend).
+        // Like weekly_hours_for_chart, the current week comes exclusively from
+        // live sessions: a mistimed archive run can leave archive rows labeled
+        // with the current week, which must not be double-counted here.
+        // Zero-minute archive rows (sub-minute sessions) don't count as activity.
+        let mut weekly_map: HashMap<String, i64> = HashMap::new();
+        {
+            let mut stmt = conn.prepare(
+                "SELECT week_label, SUM(total_min) FROM weekly_archive
+                 WHERE user_id = ?1 AND week_label <> ?2
+                 GROUP BY week_label HAVING SUM(total_min) > 0",
+            )?;
+            let rows = stmt.query_map(params![user_id, current_week_label], |r| {
+                Ok((r.get::<_, String>(0)?, r.get::<_, i64>(1)?))
+            })?;
+            for (label, minutes) in rows.filter_map(|r| r.ok()) {
+                *weekly_map.entry(label).or_insert(0) += minutes;
+            }
+        }
+        if current_week_minutes > 0 {
+            *weekly_map.entry(current_week_label).or_insert(0) += current_week_minutes;
+        }
+
+        let active_weeks = weekly_map.len() as i64;
+        let best_week = weekly_map
+            .iter()
+            .max_by(|a, b| a.1.cmp(b.1).then_with(|| b.0.cmp(a.0)))
+            .map(|(label, minutes)| (label.clone(), *minutes));
+        let weekly_minutes: Vec<i64> = week_labels
+            .iter()
+            .map(|wl| *weekly_map.get(wl).unwrap_or(&0))
+            .collect();
+
+        let mut stmt = conn.prepare(
+            "SELECT activity, SUM(mins) AS total FROM (
+                SELECT activity, SUM(minutes) AS mins FROM sessions
+                    WHERE user_id = ?1 AND ended_at IS NOT NULL GROUP BY activity
+                UNION ALL
+                SELECT activity, SUM(total_min) AS mins FROM activity_archive
+                    WHERE user_id = ?1 GROUP BY activity
+             ) GROUP BY activity ORDER BY total DESC, activity ASC",
+        )?;
+        let top_activities: Vec<(String, i64)> = stmt
+            .query_map(params![user_id], |r| Ok((r.get(0)?, r.get(1)?)))?
+            .filter_map(|r| r.ok())
+            .collect();
+
+        let active_session = match conn.query_row(
+            "SELECT activity, started_at FROM sessions
+             WHERE user_id = ?1 AND ended_at IS NULL",
+            params![user_id],
+            |r| Ok((r.get::<_, String>(0)?, r.get::<_, String>(1)?)),
+        ) {
+            Ok((activity, started_str)) => {
+                let started = NaiveDateTime::parse_from_str(&started_str, "%Y-%m-%d %H:%M:%S")?;
+                Some((activity, (now - started).num_minutes()))
+            }
+            Err(rusqlite::Error::QueryReturnedNoRows) => None,
+            Err(e) => return Err(e.into()),
+        };
+
+        Ok(Some(UserProfile {
+            username,
+            total_minutes: live_total + archive_total,
+            current_week_minutes,
+            active_weeks,
+            best_week,
+            top_activities,
+            week_labels,
+            weekly_minutes,
+            active_session,
+        }))
+    }
+
     // ── Role-assignment query methods ────────────────────────────
 
     /// Per-user activity breakdown from the live sessions table (current week).
@@ -1145,6 +1363,211 @@ mod tests {
                 .iter()
                 .any(|e| e.user_id == "u2" && e.activity == "meeting" && e.total_minutes == 60)
         );
+    }
+
+    #[test]
+    fn test_resolve_user() {
+        let (db, _temp_dir) = setup_test_db();
+
+        db.clock_in("u1", "Alice", "writing").unwrap();
+        db.clock_out("u1").unwrap();
+        {
+            let conn = db.conn.lock().unwrap();
+            conn.execute(
+                "INSERT INTO weekly_archive (user_id, username, week_label, total_min) VALUES (?1,?2,?3,?4)",
+                params!["u2", "Bob_the2nd", "KW01/2026", 60i64],
+            )
+            .unwrap();
+        }
+
+        // By user id, by exact case-insensitive name, by prefix.
+        assert_eq!(
+            db.resolve_user("u1").unwrap(),
+            Some(("u1".to_string(), "Alice".to_string()))
+        );
+        assert_eq!(
+            db.resolve_user("alice").unwrap(),
+            Some(("u1".to_string(), "Alice".to_string()))
+        );
+        assert_eq!(
+            db.resolve_user("ali").unwrap(),
+            Some(("u1".to_string(), "Alice".to_string()))
+        );
+        assert_eq!(
+            db.resolve_user("bob_the2nd").unwrap(),
+            Some(("u2".to_string(), "Bob_the2nd".to_string()))
+        );
+        assert_eq!(db.resolve_user("nobody").unwrap(), None);
+        assert_eq!(db.resolve_user("").unwrap(), None);
+        // LIKE wildcards in the query must not match everything.
+        assert_eq!(db.resolve_user("%").unwrap(), None);
+
+        // The most recent username wins.
+        db.clock_in("u1", "AliceRenamed", "writing").unwrap();
+        assert_eq!(
+            db.resolve_user("u1").unwrap(),
+            Some(("u1".to_string(), "AliceRenamed".to_string()))
+        );
+    }
+
+    #[test]
+    fn test_resolve_user_ambiguous_name_prefers_most_minutes() {
+        let (db, _temp_dir) = setup_test_db();
+        {
+            let conn = db.conn.lock().unwrap();
+            // Two pre-merge accounts share the display name "Thirsty".
+            conn.execute(
+                "INSERT INTO weekly_archive (user_id, username, week_label, total_min) VALUES (?1,?2,?3,?4)",
+                params!["small", "Thirsty", "KW01/2026", 30i64],
+            )
+            .unwrap();
+            conn.execute(
+                "INSERT INTO weekly_archive (user_id, username, week_label, total_min) VALUES (?1,?2,?3,?4)",
+                params!["big", "Thirsty", "KW01/2026", 500i64],
+            )
+            .unwrap();
+        }
+        // "small" is more recent (higher rowid), but "big" has more time.
+        assert_eq!(
+            db.resolve_user("thirsty").unwrap(),
+            Some(("big".to_string(), "Thirsty".to_string()))
+        );
+    }
+
+    #[test]
+    fn test_user_profile_no_data() {
+        let (db, _temp_dir) = setup_test_db();
+        assert!(db.user_profile("ghost", 12).unwrap().is_none());
+    }
+
+    #[test]
+    fn test_user_profile_ignores_current_week_archive_and_zero_weeks() {
+        let (db, _temp_dir) = setup_test_db();
+        let current_label = swiss_week_label();
+        let week_labels = generate_week_labels(4);
+        let week_a = &week_labels[0];
+        let week_b = &week_labels[1];
+
+        {
+            let conn = db.conn.lock().unwrap();
+            // Mistimed archive run left last week's total under the current label.
+            conn.execute(
+                "INSERT INTO weekly_archive (user_id, username, week_label, total_min) VALUES (?1,?2,?3,?4)",
+                params!["u1", "Alice", current_label, 300i64],
+            )
+            .unwrap();
+            // A real past week, and a zero-minute week that must not count.
+            conn.execute(
+                "INSERT INTO weekly_archive (user_id, username, week_label, total_min) VALUES (?1,?2,?3,?4)",
+                params!["u1", "Alice", week_a, 120i64],
+            )
+            .unwrap();
+            conn.execute(
+                "INSERT INTO weekly_archive (user_id, username, week_label, total_min) VALUES (?1,?2,?3,?4)",
+                params!["u1", "Alice", week_b, 0i64],
+            )
+            .unwrap();
+        }
+
+        let profile = db.user_profile("u1", 4).unwrap().unwrap();
+        // The mislabeled row still counts toward the all-time total...
+        assert_eq!(profile.total_minutes, 420);
+        // ...but the current-week trend bucket comes only from live sessions,
+        // and the zero-minute week is not an active week.
+        assert_eq!(profile.current_week_minutes, 0);
+        assert_eq!(profile.weekly_minutes, vec![120, 0, 0, 0]);
+        assert_eq!(profile.active_weeks, 1);
+        assert_eq!(profile.best_week, Some((week_a.clone(), 120)));
+    }
+
+    #[test]
+    fn test_user_profile_aggregates() {
+        let (db, _temp_dir) = setup_test_db();
+
+        let week_labels = generate_week_labels(4);
+        let week_a = &week_labels[0];
+        let week_b = &week_labels[1];
+
+        let monday = monday_of_current_week();
+        let monday_dt = NaiveDateTime::parse_from_str(&monday, "%Y-%m-%d %H:%M:%S").unwrap();
+        let started = (monday_dt + Duration::hours(1))
+            .format("%Y-%m-%d %H:%M:%S")
+            .to_string();
+        let ended = (monday_dt + Duration::hours(2) + Duration::minutes(30))
+            .format("%Y-%m-%d %H:%M:%S")
+            .to_string();
+
+        {
+            let conn = db.conn.lock().unwrap();
+            conn.execute(
+                "INSERT INTO weekly_archive (user_id, username, week_label, total_min) VALUES (?1,?2,?3,?4)",
+                params!["u1", "Alice", week_a, 120i64],
+            )
+            .unwrap();
+            conn.execute(
+                "INSERT INTO weekly_archive (user_id, username, week_label, total_min) VALUES (?1,?2,?3,?4)",
+                params!["u1", "Alice", week_b, 60i64],
+            )
+            .unwrap();
+            conn.execute(
+                "INSERT INTO activity_archive (user_id, username, week_label, activity, total_min) VALUES (?1,?2,?3,?4,?5)",
+                params!["u1", "Alice", week_a, "writing", 120i64],
+            )
+            .unwrap();
+            conn.execute(
+                "INSERT INTO activity_archive (user_id, username, week_label, activity, total_min) VALUES (?1,?2,?3,?4,?5)",
+                params!["u1", "Alice", week_b, "reading", 60i64],
+            )
+            .unwrap();
+            // Current-week live session: 90 minutes of writing.
+            conn.execute(
+                "INSERT INTO sessions (user_id, username, activity, started_at, ended_at, minutes)
+                 VALUES (?1,?2,?3,?4,?5,?6)",
+                params!["u1", "Alice", "writing", started, ended, 90i64],
+            )
+            .unwrap();
+            // Other users must not leak into the profile.
+            conn.execute(
+                "INSERT INTO weekly_archive (user_id, username, week_label, total_min) VALUES (?1,?2,?3,?4)",
+                params!["u2", "Bob", week_a, 999i64],
+            )
+            .unwrap();
+        }
+
+        let profile = db.user_profile("u1", 4).unwrap().unwrap();
+        assert_eq!(profile.username, "Alice");
+        assert_eq!(profile.total_minutes, 270);
+        assert_eq!(profile.current_week_minutes, 90);
+        // week_a, week_b, and the current week.
+        assert_eq!(profile.active_weeks, 3);
+        assert_eq!(profile.best_week, Some((week_a.clone(), 120)));
+        assert_eq!(
+            profile.top_activities,
+            vec![("writing".to_string(), 210), ("reading".to_string(), 60)]
+        );
+        assert_eq!(profile.week_labels, week_labels);
+        assert_eq!(profile.weekly_minutes, vec![120, 60, 0, 90]);
+        assert!(profile.active_session.is_none());
+
+        // A running session shows up as the live activity.
+        db.clock_in("u1", "Alice", "deep work").unwrap();
+        let profile = db.user_profile("u1", 4).unwrap().unwrap();
+        let (activity, elapsed) = profile.active_session.unwrap();
+        assert_eq!(activity, "deep work");
+        assert!(elapsed >= 0);
+    }
+
+    #[test]
+    fn test_user_profile_active_session_only() {
+        let (db, _temp_dir) = setup_test_db();
+        db.clock_in("u1", "Alice", "thinking").unwrap();
+
+        let profile = db.user_profile("u1", 4).unwrap().unwrap();
+        assert_eq!(profile.total_minutes, 0);
+        assert_eq!(profile.active_weeks, 0);
+        assert!(profile.best_week.is_none());
+        assert!(profile.top_activities.is_empty());
+        assert_eq!(profile.active_session.unwrap().0, "thinking");
     }
 
     #[test]


### PR DESCRIPTION
## What

New command **`/clock user [@user|name]`** (alias **`/clock me`**) that renders a per-user PNG profile card giving a view of what each person actually does:

- **Header** with the user's name and a live `● working on X · 42m` status when they're clocked in
- **Stat tiles**: all-time total, this week, best week (with its week label), active weeks
- **"What they do"**: all-time activity breakdown bars with durations and share percentages (top 6, `+ N more` overflow line)
- **Last 12 weeks**: trend strip with the current week highlighted and the peak labeled
- Text-embed fallback (same data, monospace bars) if PNG rendering ever fails, truncated to Discord's embed limits

Rendered in the same near-black theme as the leaderboard card.

| | |
|---|---|
| Lookup | `/clock user` → yourself · `@mention` · user id · case-insensitive name (prefix fallback) |
| Trend window | 12 weeks (matches `/clock chart` default) |

## Implementation notes

- **`db::resolve_user`** — finds a user by id or stored username across `sessions` + both archives; most recent record wins. When one display name maps to several pre-merge accounts (the `merge_clock_user.py` situation), the account with the most tracked time wins instead of an arbitrary row. LIKE wildcards in queries are escaped.
- **`db::user_profile`** — aggregates all-time totals (live sessions + `weekly_archive`), per-activity totals (live + `activity_archive`), per-week history, best week, active weeks, and the running session. Follows the `weekly_hours_for_chart` convention: the current-week bucket comes **exclusively from live sessions**, so archive rows mislabeled with the current week (mistimed Monday archive run) are not double-counted; zero-minute archived weeks don't count as active weeks.
- **`chart::render_user_card`** — pure-memory PNG like the existing renderers; image height adapts to the number of activity rows.
- **Mentions are parsed from the command text** (`<@id>` / `<@!id>`), not taken from `msg.mentions` — Discord adds the replied-to author to the mentions array on reply-with-ping, which would otherwise silently render the wrong person's profile.
- DB errors during name resolution report "profile unavailable" rather than masquerading as "user not found".

## Testing

- 9 new unit tests (resolution incl. ambiguous names, profile aggregation, current-week-collision + zero-week edge cases, card rendering incl. empty profile): **42 passed, 0 failed**
- Sample render inspected visually (stat tiles, bars, trend, live status all within bounds)
- Multi-agent review (4 dimensions, adversarially verified findings) — all confirmed findings fixed in this PR
